### PR TITLE
show that Expect.That requires a lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ Use Expect.That and use expressions to tell your unit testing what you want to d
 
 Examples:
 -------------------------------------------------
-* Expect.That(value == true) --> Assert.IsTrue
-* Expect.That(value == false) --> Assert.IsFalse
-* Expect.That(value == null) --> Assert.IsNull
-* Expect.That(value != null) --> Assert.IsNotNull
-* Expect.That(result == expected) --> Assert.AreEqual
-* Expect.That(result != expected) --> Assert.AreNotEqual
-* Expect.That(result is expectedType) --> Assert.IsInstanceOfType
-* Expect.That(aString.StartsWith(subString))	--> StringAssert.StartsWith
-* Expect.That(aString.EndsWith(subString)) --> StringAssert.EndsWith
-* Expect.That(aString.Contains(subString)) --> StringAssert.Contains
-* Expect.That(aCollection == expected) --> CollectionAssert.AreEqual
-* Expect.That(aCollection != expected) --> CollectionAssert.AreNotEqual
-* Expect.That(aCollection.Contains(value)) --> CollectionAssert.Contains
+* Expect.That(() => value == true) → Assert.IsTrue
+* Expect.That(() => value == false) → Assert.IsFalse
+* Expect.That(() => value == null) → Assert.IsNull
+* Expect.That(() => value != null) → Assert.IsNotNull
+* Expect.That(() => result == expected) → Assert.AreEqual
+* Expect.That(() => result != expected) → Assert.AreNotEqual
+* Expect.That(() => result is expectedType) → Assert.IsInstanceOfType
+* Expect.That(() => aString.StartsWith(subString)) → StringAssert.StartsWith
+* Expect.That(() => aString.EndsWith(subString)) → StringAssert.EndsWith
+* Expect.That(() => aString.Contains(subString)) → StringAssert.Contains
+* Expect.That(() => aCollection == expected) → CollectionAssert.AreEqual
+* Expect.That(() => aCollection != expected) → CollectionAssert.AreNotEqual
+* Expect.That(() => aCollection.Contains(value)) → CollectionAssert.Contains
 
 Currently supports NUnit & MSTest


### PR DESCRIPTION
According to [the announcement](http://blog.drorhelper.com/2015/04/asserthelper-v1-released.html), we like lambdas.